### PR TITLE
Wrap router with http.CrossOriginProtection for CSRF defence

### DIFF
--- a/app/server/server.go
+++ b/app/server/server.go
@@ -213,6 +213,7 @@ func (s *Server) routes() http.Handler {
 		rest.SizeLimit(s.bodySizeLimit()),
 		rest.AppInfo("stash", "umputun", s.Version),
 		rest.Ping,
+		http.NewCrossOriginProtection().Handler,
 	)
 
 	// determine auth middleware for protected routes

--- a/app/server/server_test.go
+++ b/app/server/server_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"strings"
 	"testing"
 	"time"
 
@@ -398,6 +399,62 @@ func TestServer_Handler_BaseURL(t *testing.T) {
 		require.Len(t, st.SetCalls(), 1)
 		assert.Equal(t, "newkey", st.SetCalls()[0].Key)
 	})
+}
+
+func TestServer_CrossOriginProtection(t *testing.T) {
+	st := &mocks.KVStoreMock{
+		SetFunc:  func(_ context.Context, _ string, _ []byte, _ string) (bool, error) { return true, nil },
+		ListFunc: func(_ context.Context, _ enum.SecretsFilter) ([]store.KeyInfo, error) { return nil, nil },
+		GetWithFormatFunc: func(_ context.Context, _ string) ([]byte, string, error) {
+			return nil, "", store.ErrNotFound
+		},
+	}
+	srv := newTestServer(t, st)
+	router := srv.routes()
+
+	tests := []struct {
+		name          string
+		method        string
+		path          string
+		secFetchSite  string
+		origin        string
+		host          string
+		wantForbidden bool
+	}{
+		{name: "GET allowed without headers", method: "GET", path: "/kv/foo"},
+		{name: "PUT same-origin allowed", method: "PUT", path: "/kv/foo", secFetchSite: "same-origin"},
+		{name: "PUT none allowed (direct nav)", method: "PUT", path: "/kv/foo", secFetchSite: "none"},
+		{name: "PUT cross-site rejected", method: "PUT", path: "/kv/foo",
+			secFetchSite: "cross-site", wantForbidden: true},
+		{name: "PUT same-site rejected (subdomain)", method: "PUT", path: "/kv/foo",
+			secFetchSite: "same-site", wantForbidden: true},
+		{name: "PUT origin matches host allowed", method: "PUT", path: "/kv/foo",
+			origin: "http://example.com", host: "example.com"},
+		{name: "PUT origin mismatch rejected", method: "PUT", path: "/kv/foo",
+			origin: "http://evil.com", host: "example.com", wantForbidden: true},
+		{name: "PUT no headers (non-browser) allowed", method: "PUT", path: "/kv/foo"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest(tt.method, tt.path, strings.NewReader("value"))
+			if tt.secFetchSite != "" {
+				req.Header.Set("Sec-Fetch-Site", tt.secFetchSite)
+			}
+			if tt.origin != "" {
+				req.Header.Set("Origin", tt.origin)
+			}
+			if tt.host != "" {
+				req.Host = tt.host
+			}
+			rec := httptest.NewRecorder()
+			router.ServeHTTP(rec, req)
+			if tt.wantForbidden {
+				assert.Equal(t, http.StatusForbidden, rec.Code, "should be rejected as cross-origin")
+				return
+			}
+			assert.NotEqual(t, http.StatusForbidden, rec.Code, "should not be rejected as cross-origin")
+		})
+	}
 }
 
 func newTestServer(t *testing.T, st KVStore) *Server {


### PR DESCRIPTION
Adds Go 1.25's `http.NewCrossOriginProtection().Handler` to the global middleware chain in `app/server/server.go`. One line of code, ~50 lines of test.

### Why

Today the only CSRF defence on the cookie session is `SameSite=Strict`, which has known gaps:

- **Firefox does not default to `SameSite=Lax`** on its release channel and has [no plans to change in 2025](https://bugzilla.mozilla.org/show_bug.cgi?id=1617609)
- **subdomain attacks bypass `SameSite` entirely** -- it operates on _site_ (registrable domain), not _origin_, so an attacker controlling any subdomain on the same registrable domain can issue same-site POSTs with the session cookie attached
- **Chrome's "Lax+POST" two-minute window** keeps cookies without an explicit `SameSite` available across sites for 120s after navigation

`http.CrossOriginProtection` checks the browser-set `Sec-Fetch-Site` header (a [forbidden header](https://fetch.spec.whatwg.org/#forbidden-header-name) JS cannot forge, shipped in all major browsers since 2023) with an `Origin` vs `Host` fallback for older clients. Unlike `SameSite`, it distinguishes _same-origin_ from _same-site_ -- subdomain attacks are blocked.

OWASP elevated this algorithm from defence-in-depth to a primary CSRF defence in [its cheatsheet](https://cheatsheetseries.owasp.org/cheatsheets/Cross-Site_Request_Forgery_Prevention_Cheat_Sheet.html) in December 2025.

### What changed

- `app/server/server.go` -- one line in the `router.Use(...)` block
- `app/server/server_test.go` -- new `TestServer_CrossOriginProtection` covering same-origin / cross-site / origin-host-mismatch / non-browser cases

### Behaviour notes

- HTMX-driven POSTs from the web UI run as same-origin requests, so `Sec-Fetch-Site: same-origin` is sent and the middleware passes them through. Verified end-to-end via the new test.
- `/kv/*` API consumers (curl, scripts, server-to-server, the Go client library) do not send `Sec-Fetch-Site` -- the middleware treats this as a non-browser request and lets them through. Token-authenticated API integrations are unaffected.
- A cross-origin browser POST/PUT/DELETE to any state-changing endpoint (e.g. an attacker page issuing `fetch()` against `/kv/foo` or `/web/keys`) is now rejected with 403 before reaching the handler.

### References

- [Go 1.25 release notes -- net/http.CrossOriginProtection](https://go.dev/doc/go1.25#nethttppkgnethttp)
- [pkg.go.dev -- http.CrossOriginProtection](https://pkg.go.dev/net/http#CrossOriginProtection)
- Filippo Valsorda, [Cross-Site Request Forgery](https://words.filippo.io/csrf/) -- the research the stdlib middleware is based on
- [OWASP CSRF Cheatsheet](https://cheatsheetseries.owasp.org/cheatsheets/Cross-Site_Request_Forgery_Prevention_Cheat_Sheet.html)
- [Datasette PR #2689](https://github.com/simonw/datasette/pull/2689) -- production migration off CSRF tokens to this algorithm in April 2026