### PR TITLE
Bump go to 1.26, add missing workflow hardening

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,10 +20,10 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: set up go 1.25
+      - name: set up go 1.26
         uses: actions/setup-go@v6
         with:
-          go-version: "1.25"
+          go-version: "1.26"
         id: go
 
       - name: build and test

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -6,6 +6,9 @@ on:
     types: [completed]
     # NOTE: Do NOT add `branches:` filter here - it breaks tag builds
 
+permissions:
+  contents: read
+
 env:
   REGISTRY_GHCR: ghcr.io
   REGISTRY_DOCKER: docker.io

--- a/.github/workflows/publish-java.yml
+++ b/.github/workflows/publish-java.yml
@@ -16,6 +16,8 @@ jobs:
     steps:
       - name: checkout
         uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - name: setup java
         uses: actions/setup-java@v5

--- a/.github/workflows/publish-python.yml
+++ b/.github/workflows/publish-python.yml
@@ -16,6 +16,8 @@ jobs:
     steps:
       - name: checkout
         uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - name: setup python
         uses: actions/setup-python@v6

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
       - name: set up go
         uses: actions/setup-go@v6
         with:
-          go-version: "1.25"
+          go-version: "1.26"
 
       - name: run goreleaser
         uses: goreleaser/goreleaser-action@v7

--- a/app/store/audit_test.go
+++ b/app/store/audit_test.go
@@ -23,7 +23,7 @@ func TestStore_AuditLog(t *testing.T) {
 		now := time.Now()
 		entries := []AuditEntry{
 			{Timestamp: now.Add(-2 * time.Hour), Action: enum.AuditActionRead, Key: "app/config", Actor: "admin", ActorType: enum.ActorTypeUser, Result: enum.AuditResultSuccess, IP: "192.168.1.1", UserAgent: "test/1.0"},
-			{Timestamp: now.Add(-1 * time.Hour), Action: enum.AuditActionUpdate, Key: "app/config", Actor: "admin", ActorType: enum.ActorTypeUser, Result: enum.AuditResultSuccess, ValueSize: intPtr(100)},
+			{Timestamp: now.Add(-1 * time.Hour), Action: enum.AuditActionUpdate, Key: "app/config", Actor: "admin", ActorType: enum.ActorTypeUser, Result: enum.AuditResultSuccess, ValueSize: new(100)},
 			{Timestamp: now, Action: enum.AuditActionRead, Key: "db/password", Actor: "token:abcd", ActorType: enum.ActorTypeToken, Result: enum.AuditResultDenied},
 		}
 
@@ -161,8 +161,4 @@ func TestStore_AuditLog(t *testing.T) {
 		assert.Len(t, results, 1)
 		assert.Equal(t, "b", results[0].Key)
 	})
-}
-
-func intPtr(i int) *int {
-	return &i
 }

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/umputun/stash
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/BurntSushi/toml v1.6.0


### PR DESCRIPTION
Four maintenance items, no functional changes to the server.

The `go` directive moves to 1.26.0 with the workflow `go-version` bumped to match. `umputun/baseimage:buildgo-latest` is already built on `golang:1.26-alpine`, so the Docker build needs nothing. Worth deciding explicitly: `lib/stash` ships from this same module, so consumers of the Go SDK now need Go 1.26 or an automatic toolchain download. If you would rather keep the SDK reachable from older toolchains, say so and I will drop the directive bump and keep the rest.

With the language version at 1.26 the `modernize` linter flags the `intPtr` helper in `app/store/audit_test.go`, since `new(100)` now expresses the same thing; the helper is removed rather than the rule silenced.

`docker.yml` had no top-level `permissions` block and inherited the repository default. Both of its jobs already declare `contents: read` and `packages: write`, so a top-level `contents: read` only affects what a future job would start with.

`publish-java.yml` and `publish-python.yml` checked out without `persist-credentials: false`, unlike every other workflow here. Java passes its publishing credentials explicitly and Python uses OIDC, so neither needs the checkout token.

Dependency and action bumps are left to the open dependabot PRs.
